### PR TITLE
Switch to sha256 password hashing

### DIFF
--- a/inc/system/class.SessionAccountHandler.php
+++ b/inc/system/class.SessionAccountHandler.php
@@ -179,9 +179,15 @@ class SessionAccountHandler {
 				return false;
 			}
 
-			if (AccountHandler::comparePasswords($password, $Account['password'])) {
+			if (AccountHandler::comparePasswords($password, $Account['password'], $Account['salt'])) {
+
 				$this->setAccount($Account);
 				$this->setSession();
+
+				// replace old md5 with new sha256 hash
+				if (strlen($Account['salt']) < 1) {
+					AccountHandler::setNewPassword($username, $password);
+				}
 
 				return true;
 			}


### PR DESCRIPTION
Use sha256 as passwort hashing algorithm and use correct salt. The solution is backward compatible.

(the $PREFIX_account table needs a column 'salt CHAR(64))

Replaced random values generator with a potentially crytographic strong one.
