### PR TITLE
Import activity category for fitlog files

### DIFF
--- a/inc/import/parser/class.ParserFITLOGSingle.php
+++ b/inc/import/parser/class.ParserFITLOGSingle.php
@@ -47,7 +47,11 @@ class ParserFITLOGSingle extends ParserAbstractSingleXML {
 	 */
 	protected function parseGeneralValues() {
 		$this->TrainingObject->setTimestamp( strtotime((string)$this->XML['StartTime']) );
-		$this->TrainingObject->setSportid( Configuration::General()->mainSport() );
+		
+		if (!empty($this->XML['categoryName']))
+			$this->guessSportID( (string)$this->XML['categoryName'] );
+		else
+			$this->TrainingObject->setSportid( Configuration::General()->mainSport() );
 
 		if (!empty($this->XML->Duration['TotalSeconds']))
 			$this->TrainingObject->setTimeInSeconds(round((double)$this->XML->Duration['TotalSeconds']));


### PR DESCRIPTION
Import the name of the activity category if it matches the sport types configured in Runalyze. This issue came up to my mind while I worked (and still work) on my private migration from SportTracks 3 to Runalyze. I want to map all the categories from my current data onto the same categories in Runalyze.

The same logic applies in the ST3 importer.