### PR TITLE
Correct lap time due to error in export

### DIFF
--- a/inc/import/parser/class.ParserXMLpolarSingle.php
+++ b/inc/import/parser/class.ParserXMLpolarSingle.php
@@ -72,14 +72,6 @@ class ParserXMLpolarSingle extends ParserAbstractSingleXML {
 			$this->TrainingObject->setPulseAvg((int)$this->XML->result->{'heart-rate'}->average);
 			$this->TrainingObject->setPulseMax((int)$this->XML->result->{'heart-rate'}->maximum);
 		}
-		
-		if (isset($this->XML->note)) {
-            $this->TrainingObject->setNotes((string)$this->XML->note);
-        }
-
-        if (isset($this->XML->name)) {
-            $this->TrainingObject->setComment((string)$this->XML->name);
-        }
 	}
 
 	/**
@@ -91,7 +83,13 @@ class ParserXMLpolarSingle extends ParserAbstractSingleXML {
 				$distance = round(((double)$Lap->distance)/1000, 2);
 				$Time = new Duration((string)$Lap->duration);
 
-				$this->TrainingObject->Splits()->addSplit($distance, $Time->seconds());
+				$seconds = $Time->seconds();
+
+                if (($seconds / (double)$Lap->distance) < 0.06) {
+                    $seconds = $seconds * 60;
+                }
+
+				$this->TrainingObject->Splits()->addSplit($distance, $seconds);
 			}
 		}
 	}

--- a/inc/import/parser/class.ParserXMLpolarSingle.php
+++ b/inc/import/parser/class.ParserXMLpolarSingle.php
@@ -72,6 +72,14 @@ class ParserXMLpolarSingle extends ParserAbstractSingleXML {
 			$this->TrainingObject->setPulseAvg((int)$this->XML->result->{'heart-rate'}->average);
 			$this->TrainingObject->setPulseMax((int)$this->XML->result->{'heart-rate'}->maximum);
 		}
+		
+		if (isset($this->XML->note)) {
+            $this->TrainingObject->setNotes((string)$this->XML->note);
+        }
+
+        if (isset($this->XML->name)) {
+            $this->TrainingObject->setComment((string)$this->XML->name);
+        }
 	}
 
 	/**


### PR DESCRIPTION
The lap time is not exported correctly by polarpersonaltrainer.com, e.g. a lap time of 0:30:00 min is exported as 0:00:30 min. This should be corrected when importing.