### PR TITLE
Extended STATISTICS plugin to display the "all sport summary"

### DIFF
--- a/inc/core/Dataset/Keys/Temperature.php
+++ b/inc/core/Dataset/Keys/Temperature.php
@@ -62,7 +62,7 @@ class Temperature extends AbstractKey
 	{
 		if (
 			!$context->activity()->weather()->temperature()->isUnknown() &&
-			($context->hasSport() || $context->sport()->isOutside())
+			!($context->hasSport() && !$context->sport()->isOutside())
 		) {
 			return \Runalyze\Activity\Temperature::format(
 				$context->activity()->weather()->temperature()->value(),

--- a/inc/core/Dataset/Query.php
+++ b/inc/core/Dataset/Query.php
@@ -191,22 +191,24 @@ class Query
 	 */
 	public function fetchSummaryForTimerange($sportid, $timerange = 604800, $timeStart = 0, $timeEnd = false)
 	{
-		return $this->PDO->query(
-			'SELECT
-				`sportid`,
+		$Query = '
+		        SELECT
+				'.(((int)$sportid > 0)?'`sportid`':'0').',
 				SUM(IF(`distance`>0,`s`,0)) as `'.Keys\Pace::DURATION_SUM_WITH_DISTANCE_KEY.'`,
 				SUM(1) as `num`,
 				'.$this->queryToSummarizeActiveKeys().',
 				'.$this->queryToSelectTimerange($timerange, $timeEnd, 'timerange').'
 			FROM `'.PREFIX.'training` AS `t`
 			WHERE
-				`sportid` = '.(int)$sportid.' AND
+				'.(((int)$sportid > 0)?'`sportid` = '.(int)$sportid.' AND':''). '
 				`accountid` = '.(int)$this->AccountID.' AND
 				'.$this->whereTimeIsBetween($timeStart, $timeEnd).' AND
 				'.$this->wherePrivacyIsOkay().'
-			GROUP BY `timerange`, `sportid`
-			ORDER BY `timerange` ASC'
-		)->fetchAll();
+				GROUP BY `timerange`
+				'.(((int)$sportid > 0)?', `sportid`':'').'
+				ORDER BY `timerange` ASC';
+
+		return $this->PDO->query($Query)->fetchAll();
 	}
 
 	/**

--- a/plugin/RunalyzePluginStat_Statistiken/class.RunalyzePluginStat_Statistiken.php
+++ b/plugin/RunalyzePluginStat_Statistiken/class.RunalyzePluginStat_Statistiken.php
@@ -97,12 +97,11 @@ class RunalyzePluginStat_Statistiken extends PluginStat {
 
 		$this->initVariables();
 
-		$this->setSportsNavigation();
+		$this->setSportsNavigation(true, true);
 		$this->setYearsNavigation(true, true, true);
 		$this->setOwnNavigation();
 
-		$this->setHeader($this->Sport['name'].': '.$this->getYearString());
-
+		$this->setHeaderWithSportAndYear();
 	}
 
 	/**


### PR DESCRIPTION
I've extended the plug-in to display a summary of all sports. Is use
this feature to compare the calories burned each week.

I had to patch inc/core/Dataset/Keys/Temperature.php. I think that the original check
($context->hasSport() || $context->sport()->isOutside())
is wrong: if a context has no sport, then accessing $context->sport()->isOutside() raises an exception.