### PR TITLE
Allowed from all for update to 2.4.

### DIFF
--- a/build/.htaccess
+++ b/build/.htaccess
@@ -5,3 +5,7 @@ allow from 127.0.0.1 localhost ::1
 <FilesMatch "\.js$">
     Allow from all
 </FilesMatch>
+
+<FilesMatch "global\.routefix\.php$">
+    Allow from all
+</FilesMatch>


### PR DESCRIPTION
Otherwise it makes no sense linking to that script from the "update success"-message.