### PR TITLE
Add initial webapp manifest

### DIFF
--- a/app/Resources/views/base.html.twig
+++ b/app/Resources/views/base.html.twig
@@ -15,6 +15,7 @@
             {% endblock %}
 
             <link rel="shortcut icon" type="image/x-icon" href="{{ asset('favicon.ico') }}">
+            <link rel="manifest" href="{{ asset('assets/appmanifest.json') }}">
 
             {% block html_head_locales %}
                 {% for key, locale in locales %}

--- a/app/Resources/views/system/base.html.twig
+++ b/app/Resources/views/system/base.html.twig
@@ -8,6 +8,7 @@
         <title>{{ page_title|default('RUNALYZE') }}</title>
 
         <link href="{{ asset('favicon.ico') }}" rel="shortcut icon" type="image/x-icon">
+        <link href="{{ asset('assets/appmanifest.json') }}" rel="manifest">
         <link href="{{ asset('assets/css/runalyze-installer.css') }}" rel="stylesheet" type="text/css">
         <link href="http://fonts.googleapis.com/css?family=Lato&subset=latin,latin-ext" rel="stylesheet" type="text/css">
     {% endblock head %}

--- a/inc/tpl/tpl.Frontend.header.php
+++ b/inc/tpl/tpl.Frontend.header.php
@@ -9,6 +9,7 @@
 	<?php echo System::getCodeForAllCSSFiles(); ?>
 
 	<link rel="shortcut icon" type="image/x-icon" href="favicon.ico">
+	<link rel="manifest" href="assets/appmanifest.json">
         <?php foreach (\Runalyze\Language::availableLanguages() as $key => $lang_arr) { ?>
         <link rel="alternate" href="<?php echo System::getFullDomain(true)."?lang=".$key; ?>" hreflang="<?php echo $key; ?>" />
         <?php } ?>

--- a/inc/tpl/tpl.FrontendShared.header.php
+++ b/inc/tpl/tpl.FrontendShared.header.php
@@ -11,6 +11,7 @@
 	<?php echo System::getCodeForAllCSSFiles(); ?>
 
 	<link rel="shortcut icon" type="image/x-icon" href="favicon.ico">
+	<link rel="manifest" href="assets/appmanifest.json">
 
 	<title><?php echo $this->getPageTitle(); ?> - RUNALYZE</title>
 

--- a/inc/tpl/tpl.FrontendSharedIframe.header.php
+++ b/inc/tpl/tpl.FrontendSharedIframe.header.php
@@ -8,6 +8,7 @@
 	<?php echo System::getCodeForAllCSSFiles(); ?>
 
 	<link rel="shortcut icon" type="image/x-icon" href="favicon.ico" >
+	<link rel="manifest" href="assets/appmanifest.json">
 
 	<title><?php echo $this->getPageTitle(); ?> - Runalyze</title>
 

--- a/inc/tpl/tpl.adminHeader.php
+++ b/inc/tpl/tpl.adminHeader.php
@@ -9,6 +9,7 @@
 	<?php echo System::getCodeForAllCSSFiles(); ?>
 
 	<link rel="shortcut icon" type="image/x-icon" href="favicon.ico">
+	<link rel="manifest" href="assets/appmanifest.json">
 
 	<title><?php echo $title; ?></title>
 

--- a/web/assets/appmanifest.json
+++ b/web/assets/appmanifest.json
@@ -1,0 +1,14 @@
+{
+  "name": "RUNALYZE",
+  "description": "Runalyze analyzes your complete training, calculates your shape, computes prognoses and visualizes your training in plots - more detailed than any other sports diary.",
+  "short_name": "RUNALYZE",
+  "start_url": "/",
+  "display": "standalone",
+  "theme_color": "#222222",
+  "background_color": "#222222",
+  "icons": [
+    {
+      "src": "/favicon.ico"
+    }
+  ]
+}


### PR DESCRIPTION
According to the [WebAppManifest](https://www.w3.org/TR/appmanifest/), here is a simple web app manifest for Runalyze.

After installing Runalyze on the home screen of a mobile device, it will have some additional features:
* short splash screen in `#222222` with "Runalyze" during loading
* no URL-Bar any more (makes scrolling more comfortable, since the page always has the full height of the screen)
