### PR TITLE
fixes links in search result

### DIFF
--- a/lib/runalyze.lib.databrowser.js
+++ b/lib/runalyze.lib.databrowser.js
@@ -31,9 +31,16 @@ Runalyze.DataBrowser = (function($, Parent){
 			e.stopPropagation();
 
 			if ($(this).data('action') == 'delete') {
-				self.deleteActivity($(this).data('activityid'), $(this).data('confirm'));
+				Parent.Training.deleteActivity($(this).data('activityid'), $(this).data('confirm'), {
+					useOverlay: true
+				});
 			} else if ($(this).data('action') == 'privacy') {
-				self.changePrivacyOfActivity($(this).data('activityid'));
+				Parent.Training.changePrivacyOfActivity($(this).data('activityid'), {
+					beforeSend: function() {
+						$("#data-browser-inner").addClass('loading');
+					},
+					success: self.reload
+				});
 			}
 		});
 	}
@@ -77,26 +84,6 @@ Runalyze.DataBrowser = (function($, Parent){
 			start: start,
 			end: end
 		};
-	};
-
-	self.deleteActivity = function(id, confirmMsg) {
-		if (confirmMsg) {
-			if (!window.confirm(confirmMsg)) {
-				return false;
-			}
-		}
-
-		Parent.Overlay.load(
-			Parent.Training.url(id) + "/delete",
-			{ size: 'small' }
-		);
-	};
-
-	self.changePrivacyOfActivity = function(id) {
-		$("#data-browser-inner").addClass('loading');
-		$.ajax(Parent.Training.url(id) + "?action=changePrivacy&silent=true").done(function(){
-			self.reload();
-		});
 	};
 
 	Parent.addInitHook('init-databrowser', self.init);

--- a/lib/runalyze.lib.feature.js
+++ b/lib/runalyze.lib.feature.js
@@ -222,9 +222,17 @@ Runalyze.Feature = (function($, Parent){
 				$("#searchResult").loadDiv(url+'?pager=true', data, {success: function(){
 					$('#searchResult').find('.submenu .link').unbind('click').bind('click', function(){
 						if ($(this).data('action') == 'delete') {
-							self.deleteActivity($(this).data('activityid'), $(this).data('confirm'));
+							Parent.Training.deleteActivity($(this).data('activityid'), $(this).data('confirm'), {
+								success: function() {
+									$('#search').submit();
+								}
+							});
 						} else if ($(this).data('action') == 'privacy') {
-							self.changePrivacyOfActivity($(this).data('activityid'));
+							Parent.Training.changePrivacyOfActivity($(this).data('activityid'), {
+								success: function() {
+									$('#search').submit();
+								}
+							});
 						}
 					});
 				}});
@@ -265,25 +273,6 @@ Runalyze.Feature = (function($, Parent){
 
 	self.initToggle = function() {
 		initToggle();
-	};
-
-	self.deleteActivity = function(id, confirmMsg) {
-		if (confirmMsg) {
-			if (!window.confirm(confirmMsg)) {
-				return false;
-			}
-		}
-
-		$.ajax(Parent.Training.url(id) + "/delete").done(function(){
-			$('#search').submit();
-		});
-	};
-
-
-	self.changePrivacyOfActivity = function(id) {
-		$.ajax(Parent.Training.url(id) + "?action=changePrivacy&silent=true").done(function(){
-			$('#search').submit();
-		});
 	};
 
 	Parent.addLoadHook('init-feature', self.init);

--- a/lib/runalyze.lib.feature.js
+++ b/lib/runalyze.lib.feature.js
@@ -219,7 +219,15 @@ Runalyze.Feature = (function($, Parent){
 			});
 
 			if (formID == "search" && $("form.ajax input[name=send_to_multiEditor]:checked").length == 0) {
-				$("#searchResult").loadDiv(url+'?pager=true', data);
+				$("#searchResult").loadDiv(url+'?pager=true', data, {success: function(){
+					$('#searchResult').find('.submenu .link').unbind('click').bind('click', function(){
+						if ($(this).data('action') == 'delete') {
+							self.deleteActivity($(this).data('activityid'), $(this).data('confirm'));
+						} else if ($(this).data('action') == 'privacy') {
+							self.changePrivacyOfActivity($(this).data('activityid'));
+						}
+					});
+				}});
 				return false;
 			}
 
@@ -257,6 +265,25 @@ Runalyze.Feature = (function($, Parent){
 
 	self.initToggle = function() {
 		initToggle();
+	};
+
+	self.deleteActivity = function(id, confirmMsg) {
+		if (confirmMsg) {
+			if (!window.confirm(confirmMsg)) {
+				return false;
+			}
+		}
+
+		$.ajax(Parent.Training.url(id) + "/delete").done(function(){
+			$('#search').submit();
+		});
+	};
+
+
+	self.changePrivacyOfActivity = function(id) {
+		$.ajax(Parent.Training.url(id) + "?action=changePrivacy&silent=true").done(function(){
+			$('#search').submit();
+		});
 	};
 
 	Parent.addLoadHook('init-feature', self.init);

--- a/lib/runalyze.lib.feature.js
+++ b/lib/runalyze.lib.feature.js
@@ -221,14 +221,15 @@ Runalyze.Feature = (function($, Parent){
 			if (formID == "search" && $("form.ajax input[name=send_to_multiEditor]:checked").length == 0) {
 				$("#searchResult").loadDiv(url+'?pager=true', data, {success: function(){
 					$('#searchResult').find('.submenu .link').unbind('click').bind('click', function(){
-						if ($(this).data('action') == 'delete') {
-							Parent.Training.deleteActivity($(this).data('activityid'), $(this).data('confirm'), {
+						var element = $(this);
+						if (element.data('action') == 'delete') {
+							Parent.Training.deleteActivity(element.data('activityid'), element.data('confirm'), {
 								success: function() {
-									$('#search').submit();
+									element.closest('tr').remove();
 								}
 							});
-						} else if ($(this).data('action') == 'privacy') {
-							Parent.Training.changePrivacyOfActivity($(this).data('activityid'), {
+						} else if (element.data('action') == 'privacy') {
+							Parent.Training.changePrivacyOfActivity(element.data('activityid'), {
 								success: function() {
 									$('#search').submit();
 								}

--- a/lib/runalyze.lib.training.js
+++ b/lib/runalyze.lib.training.js
@@ -76,6 +76,31 @@ Runalyze.Training = (function($, Parent){
 		Parent.Overlay.container().loadDiv($("form#training").attr("action"), {'data': xml});
 	};
 
+	self.deleteActivity = function(id, confirmMsg, settings) {
+		if (confirmMsg) {
+			if (!window.confirm(confirmMsg)) {
+				return false;
+			}
+		}
+
+		settings = $.extend({}, {size:'small', useOverlay: false}, settings);
+
+		if(settings.useOverlay) {
+			Parent.Overlay.load(
+				Parent.Training.url(id) + "/delete",
+				settings
+			);
+			return false;
+		}
+
+		$.ajax(self.url(id) + "/delete", settings);
+	};
+
+
+	self.changePrivacyOfActivity = function(id, settings) {
+		$.ajax(self.url(id) + "?action=changePrivacy&silent=true", settings);
+	};
+
 	Parent.addLoadHook('init-training-links', self.initLinks);
 
 	return self;


### PR DESCRIPTION
The Links "Make public"/"Make private" and "Delete activity" withiuin the search result form are not working.
This change adds event listeners to the search result's submenu to make the functions work properly.


I would like to have input on my changes, where and how I should implement the functions `Runalyze.Feature.deleteActivity()` and `Runalyze.Feature.changePrivacyOfActivity()` because they are very similar to the functions [Runalyze.DataBrowser.deleteActivity()](https://github.com/Runalyze/Runalyze/blob/87b85fcdbfbea0ae75b7e69c8148984f147d9d7a/lib/runalyze.lib.databrowser.js#L82) and [Runalyze.DataBrowser.changePrivacyOfActivity()](https://github.com/Runalyze/Runalyze/blob/87b85fcdbfbea0ae75b7e69c8148984f147d9d7a/lib/runalyze.lib.databrowser.js#L95)

Perhaps one should add these two functions to `Runalyze.Training` and just provide some callbacks like success and start?