### PR TITLE
apikey for Thunderforest leaflet layers

### DIFF
--- a/app/config/default_config.yml
+++ b/app/config/default_config.yml
@@ -16,6 +16,7 @@ parameters:
   darksky_api_key:
   nokia_here_appid:
   nokia_here_token:
+  thunderforest_api_key:
   geonames_username:
   perl_path: /usr/bin/perl
   python3_path: /usr/bin/python3

--- a/inc/class.Frontend.php
+++ b/inc/class.Frontend.php
@@ -104,6 +104,7 @@ class Frontend {
         define('OPENWEATHERMAP_API_KEY', $this->yamlConfig['openweathermap_api_key']);
 	    define('NOKIA_HERE_APPID', $this->yamlConfig['nokia_here_appid']);
 	    define('NOKIA_HERE_TOKEN', $this->yamlConfig['nokia_here_token']);
+	    define('THUNDERFOREST_API_KEY', $this->yamlConfig['thunderforest_api_key']);
 	    define('PERL_PATH', $this->yamlConfig['perl_path']);
 	    define('TTBIN_PATH', $this->yamlConfig['ttbin_path']);
 	    define('GEONAMES_USERNAME', $this->yamlConfig['geonames_username']);

--- a/inc/html/class.Ajax.php
+++ b/inc/html/class.Ajax.php
@@ -83,6 +83,10 @@ class Ajax {
 		if (defined('NOKIA_HERE_APPID') && NOKIA_HERE_APPID != '' && defined('NOKIA_HERE_TOKEN') && NOKIA_HERE_TOKEN != '') {
 			echo self::wrapJS('Runalyze.Options.setNokiaLayerAuth("'.NOKIA_HERE_APPID.'", "'.NOKIA_HERE_TOKEN.'")');
 		}
+		if (defined('THUNDERFOREST_API_KEY') && THUNDERFOREST_API_KEY != '') {
+                        echo self::wrapJS('Runalyze.Options.setThunderforestLayerAuth("'.THUNDERFOREST_API_KEY.'")');
+                }
+
 	}
 
 	/**

--- a/lib/leaflet/runalyze.leaflet.layers.js
+++ b/lib/leaflet/runalyze.leaflet.layers.js
@@ -42,7 +42,8 @@ RunalyzeLeaflet.getNewLayers = function(){
 			}
 		),
 		'Thunderforest': L.tileLayer(
-			'//{s}.tile.thunderforest.com/outdoors/{z}/{x}/{y}.png', {
+			'//{s}.tile.thunderforest.com/outdoors/{z}/{x}/{y}.png?{apikey}', {
+				apikey: (Runalyze.Options.thunderforestAuth()!=""?"apikey=".concat(Runalyze.Options.thunderforestAuth()):""),
 				attribution: '&copy; <a href="http://www.opencyclemap.org">OpenCycleMap</a>, ' +
 					'&copy; <a href="http://openstreetmap.org">OpenStreetMap</a> contributors, ' +
 					'<a href="http://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>'
@@ -88,7 +89,8 @@ RunalyzeLeaflet.getNewLayers = function(){
 			}
 		),
 		'OpenCycleMap': L.tileLayer(
-			'//{s}.tile.thunderforest.com/cycle/{z}/{x}/{y}.png', {
+			'//{s}.tile.thunderforest.com/cycle/{z}/{x}/{y}.png?{apikey}', {
+				apikey: (Runalyze.Options.thunderforestAuth()!=""?"apikey=".concat(Runalyze.Options.thunderforestAuth()):""),
 				attribution: '&copy; <a href="http://www.opencyclemap.org">OpenCycleMap</a>, ' +
 					'&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
 			}

--- a/lib/leaflet/runalyze.leaflet.layers.js
+++ b/lib/leaflet/runalyze.leaflet.layers.js
@@ -7,7 +7,7 @@
  * (c) 2014 Hannes Christiansen, http://www.runalyze.de/
  */
 RunalyzeLeaflet.getNewLayers = function(){
-	return {
+	var layers = {
 		'OpenStreetMap': L.tileLayer(
 			'//{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
 				attribution: '&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
@@ -39,14 +39,6 @@ RunalyzeLeaflet.getNewLayers = function(){
 			'http://otile{s}.mqcdn.com/tiles/1.0.0/map/{z}/{x}/{y}.png', {
 				subdomains: '1234',
 				attribution: 'Tiles Courtesy of <a href="http://www.mapquest.com/" target="_blank">MapQuest</a>'
-			}
-		),
-		'Thunderforest': L.tileLayer(
-			'//{s}.tile.thunderforest.com/outdoors/{z}/{x}/{y}.png?{apikey}', {
-				apikey: (Runalyze.Options.thunderforestAuth()!=""?"apikey=".concat(Runalyze.Options.thunderforestAuth()):""),
-				attribution: '&copy; <a href="http://www.opencyclemap.org">OpenCycleMap</a>, ' +
-					'&copy; <a href="http://openstreetmap.org">OpenStreetMap</a> contributors, ' +
-					'<a href="http://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>'
 			}
 		),
 		'Hydda': L.tileLayer(
@@ -88,13 +80,6 @@ RunalyzeLeaflet.getNewLayers = function(){
 				attribution: '&copy; <a href="http://www.sigmasport.com/" target="_blank">SIGMA Sport &reg;</a>'
 			}
 		),
-		'OpenCycleMap': L.tileLayer(
-			'//{s}.tile.thunderforest.com/cycle/{z}/{x}/{y}.png?{apikey}', {
-				apikey: (Runalyze.Options.thunderforestAuth()!=""?"apikey=".concat(Runalyze.Options.thunderforestAuth()):""),
-				attribution: '&copy; <a href="http://www.opencyclemap.org">OpenCycleMap</a>, ' +
-					'&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
-			}
-		),
 		'Esri': L.tileLayer(
 			'//server.arcgisonline.com/ArcGIS/rest/services/World_Street_Map/MapServer/tile/{z}/{y}/{x}', {
 				attribution: 'Tiles: &copy; <a href="http://www.esri.com/" target="_blank">Esri</a>'
@@ -120,4 +105,24 @@ RunalyzeLeaflet.getNewLayers = function(){
 			}
 		)
 	};
+
+	if (Runalyze.Options.thunderforestAuth() != "") {
+		layers['OpenCycleMap'] = L.tileLayer(
+			'//{s}.tile.thunderforest.com/cycle/{z}/{x}/{y}.png?apikey={apikey}', {
+				apikey: Runalyze.Options.thunderforestAuth(),
+				attribution: '&copy; <a href="http://www.opencyclemap.org">OpenCycleMap</a>, ' +
+					'&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
+			}
+		);
+        layers['Thunderforest'] = L.tileLayer(
+			'//{s}.tile.thunderforest.com/outdoors/{z}/{x}/{y}.png?apikey={apikey}', {
+				apikey: Runalyze.Options.thunderforestAuth(),
+				attribution: '&copy; <a href="http://www.opencyclemap.org">OpenCycleMap</a>, ' +
+					'&copy; <a href="http://openstreetmap.org">OpenStreetMap</a> contributors, ' +
+					'<a href="http://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>'
+			}
+		);
+	}
+
+	return layers;
 };

--- a/lib/runalyze.lib.options.js
+++ b/lib/runalyze.lib.options.js
@@ -16,7 +16,8 @@ Runalyze.Options = (function($, parent){
 		sharedView:		false,
 		fadeSpeed:		200,
 		loadingClass:	'loading',
-		nokiaAuth:		{ app: 'YOUR-APP-ID', token: 'YOUR-APP-TOKEN' }
+		nokiaAuth:		{ app: 'YOUR-APP-ID', token: 'YOUR-APP-TOKEN' },
+		thunderforestApikey:	''
 	};
 
 
@@ -34,6 +35,16 @@ Runalyze.Options = (function($, parent){
 
 	self.nokiaAuth = function() {
 		return options.nokiaAuth;
+	};
+
+	self.setThunderforestLayerAuth = function(apikey) {
+		options.thunderforestApikey = apikey;
+
+		return self;
+	};
+
+	self.thunderforestAuth = function() {
+		return options.thunderforestApikey;
 	};
 
 	self.setSharedView = function(flag) {


### PR DESCRIPTION
The Thunderforest leaflet layers ("Thunderforest" and "OpenCycleMap") need an apikey. If not provided, the tiles show a watermark "apikey required".

This patch adds the thunderforest apikey to the default config, pushes it to the JS layer and uses the key in the leaflet layer definition. Note that Thunderforest returns a 403 error if the apikey parameter is empty or invalid, therefore the logic in the leaflet layer definition is a bit more complicated than desired...
