### PR TITLE
fixes an error 500 when displaying tools/vo2max-analysis

### DIFF
--- a/src/CoreBundle/Component/Tool/VO2maxAnalysis/VO2maxAnalysis.php
+++ b/src/CoreBundle/Component/Tool/VO2maxAnalysis/VO2maxAnalysis.php
@@ -65,7 +65,7 @@ class VO2maxAnalysis
 				`tr`.`distance`,
 				`tr`.`s`,
 				`tr`.`is_track`,
-				`tr`.`comment`,
+				`tr`.`title`,
 				`tr`.`pulse_avg`,
 				`tr`.`pulse_max`,
 				`tr`.`vo2max`,


### PR DESCRIPTION
column comment was renamed to title 7c3aa1d64530bdf10a61364d123111ff840788a0