### PR TITLE
pipe delimited array type accidentally converts geo hashes

### DIFF
--- a/tests/CoreBundle/Doctrine/Types/PipeDelimitedArrayTest.php
+++ b/tests/CoreBundle/Doctrine/Types/PipeDelimitedArrayTest.php
@@ -26,9 +26,37 @@ class PipeDelimitedArrayTest extends \PHPUnit_Framework_TestCase
         $this->assertNull($this->Type->convertToDatabaseValue([], $this->PlatformMock));
     }
 
-    public function testSimpleData()
+    /**
+     * @param $pipedData
+     * @param $rawData
+     * @dataProvider provideData
+     */
+    public function testSimpleData($pipedData, $rawData)
     {
-        $this->assertEquals([3.14, 42, 0], $this->Type->convertToPHPValue('3.14|42|0', $this->PlatformMock));
-        $this->assertEquals('3.14|42|0', $this->Type->convertToDatabaseValue([3.14, 42, 0], $this->PlatformMock));
+
+        $this->assertSame($pipedData, $this->Type->convertToDatabaseValue($rawData, $this->PlatformMock));
+        $this->assertSame($rawData, $this->Type->convertToPHPValue($pipedData, $this->PlatformMock));
+    }
+
+    public function provideData()
+    {
+        return [
+            [
+                '3.14|42|0',
+                [3.14, 42, 0]
+            ],
+            [
+                'foo|bar',
+                ['foo', 'bar']
+            ],
+            [
+                'coffee|abba', // hexadecimal characters only
+                ['coffee', 'abba']
+            ],
+            [
+                '68e7|1234', // first is a geohash and must not be converted
+                ['68e7', 1234]
+            ]
+        ];
     }
 }


### PR DESCRIPTION
Hi,

I wanted to add a map to the sub segments view and found that the `PipeDelimitedArray`-type wrongly converts values to integers and so the content of `\Runalyze\Bundle\CoreBundle\Entity\Route::$geohashes` contains wrong data, after it is loaded.

The reason is the conversion that is done by `$v + 0` here, and I don't exactly know why this was added, but i think this should be removed:
https://github.com/Runalyze/Runalyze/blob/9a7a7adaad77d4b5354c7d39ba42f3f692852ad7/src/CoreBundle/Doctrine/Types/PipeDelimitedArray.php#L36

If you could provide me with another test, I could try to fix this without breaking something :-)

best regards
Matthias