### PR TITLE
add map view to best sub segments view

### DIFF
--- a/app/Resources/views/activity/tool/best_sub_segments.html.twig
+++ b/app/Resources/views/activity/tool/best_sub_segments.html.twig
@@ -11,10 +11,10 @@
     {{ value.value }} <small>{{ value.unit }}</small>
 {% endmacro %}
 
-{% macro tableRow(rowLabel, baseValue, pace, from, to) %}
+{% macro tableRow(rowLabel, baseValue, pace, from, to, segmentType, segmentIndex) %}
     {% import _self as this %}
 
-    <tr class="c">
+    <tr class="c" data-segment-index="{{ segmentIndex }}" data-segment-type="{{ segmentType }}">
         <td class="l"><strong>{{ rowLabel }}</strong></td>
         <td>{{ baseValue }}</td>
         <td>{{ this.tableCellFor(pace) }}</td>
@@ -33,7 +33,8 @@
     {% set timeSegments = statistics.timeSegments %}
 
     <div class="panel-content">
-        <table class="zebra-style more-padding" style="width: 400px;">
+        {{ map|raw }}
+        <table class="zebra-style more-padding fullwidth">
             <thead>
             <tr>
                 <th colspan="2">{% trans %}Best segment{% endtrans %}</th>
@@ -52,7 +53,9 @@
                         achievedTime|duration,
                         pace(achievedTime / distance, paceUnit),
                         distanceArray[fromTo[0]],
-                        distanceArray[fromTo[1]]
+                        distanceArray[fromTo[1]],
+                        "distance",
+                        i
                     ) }}
                 {% endif %}
             {% endfor %}
@@ -68,11 +71,24 @@
                         this.tableCellFor(distance(achievedDistance)),
                         pace(time / achievedDistance, paceUnit),
                         distanceArray[fromTo[0]],
-                        distanceArray[fromTo[1]]
+                        distanceArray[fromTo[1]],
+                        "time",
+                        i
                     ) }}
                 {% endif %}
             {% endfor %}
             </tbody>
         </table>
+        <script>
+            var segments = {{ segments|json_encode|raw }};
+            var polyline = null;
+            $("tr[data-segment-index]").on("mouseover", function(){
+                var index = $(this).attr('data-segment-index');
+                var type = $(this).attr('data-segment-type');
+                polyline = L.polyline(segments[type][index], {color: 'yellow'}).addTo(RunalyzeLeaflet.map());
+            }).on("mouseout", function(){
+                RunalyzeLeaflet.map().removeLayer(polyline);
+            });
+        </script>
     </div>
 {% endblock %}

--- a/inc/training/view/class.TrainingView.php
+++ b/inc/training/view/class.TrainingView.php
@@ -128,7 +128,7 @@ class TrainingView {
 		}
 
 		if ($this->Context->hasTrackdata() && $this->Context->trackdata()->has(Model\Trackdata\Entity::TIME) && $this->Context->trackdata()->has(Model\Trackdata\Entity::DISTANCE)) {
-			$toolsLinks[] = '<li><a class="window link" data-size="big" href="activity/'.$this->Context->activity()->id().'/sub-segments-info"><i class="fa fa-fw fa-bar-chart"></i> '.__('Find best sub segments').'</a></li>';
+			$toolsLinks[] = '<li><a class="window link" data-size="normal" href="activity/'.$this->Context->activity()->id().'/sub-segments-info"><i class="fa fa-fw fa-bar-chart"></i> '.__('Find best sub segments').'</a></li>';
 		}
 
 		if (!empty($toolsLinks)) {

--- a/src/CoreBundle/Component/Activity/Tool/BestSubSegmentsStatistics.php
+++ b/src/CoreBundle/Component/Activity/Tool/BestSubSegmentsStatistics.php
@@ -74,35 +74,38 @@ class BestSubSegmentsStatistics
 
     /**
      * @param RouteEntity $route
+     * @param int $precision only add every nth point to path
      * @return array
      */
-    public function getDistanceSegmentPaths(RouteEntity $route)
+    public function getDistanceSegmentPaths(RouteEntity $route, $precision = 1)
     {
-        return $this->getSegments($this->getDistanceSegments(), $route);
+        return $this->getSegments($this->getDistanceSegments(), $route, $precision);
     }
 
     /**
      * @param RouteEntity $route
+     * @param int $precision only add every nth point to path
      * @return array
      */
-    public function getTimeSegmentPaths(RouteEntity $route)
+    public function getTimeSegmentPaths(RouteEntity $route, $precision = 1)
     {
-        return $this->getSegments($this->getTimeSegments(), $route);
+        return $this->getSegments($this->getTimeSegments(), $route, $precision);
     }
 
     /**
      * @param SubSegmentMaximization $subSegmentMaximization
      * @param RouteEntity $route
+     * @param int $precision only add every nth point to path
      * @return array
      */
-    private function getSegments(SubSegmentMaximization $subSegmentMaximization, RouteEntity $route)
+    private function getSegments(SubSegmentMaximization $subSegmentMaximization, RouteEntity $route, $precision)
     {
         $latLongs = $route->latitudesAndLongitudesFromGeohash();
         $seg = [];
         foreach($subSegmentMaximization->getAvailableSegmentLengths() as $index => $length) {
             $segIndices = $subSegmentMaximization->getIndizesOfMaximumForLengthIndex($index);
             $seg[$index] = [];
-            for($i = $segIndices[0]; $i <= $segIndices[1]; $i++){
+            for($i = $segIndices[0]; $i <= $segIndices[1]; $i+=$precision){
                 $seg[$index][] = array($latLongs['lat'][$i], $latLongs['lng'][$i]);
             }
 

--- a/src/CoreBundle/Component/Activity/Tool/BestSubSegmentsStatistics.php
+++ b/src/CoreBundle/Component/Activity/Tool/BestSubSegmentsStatistics.php
@@ -102,10 +102,10 @@ class BestSubSegmentsStatistics
     {
         $latLongs = $route->latitudesAndLongitudesFromGeohash();
         $seg = [];
-        foreach($subSegmentMaximization->getAvailableSegmentLengths() as $index => $length) {
+        foreach ($subSegmentMaximization->getAvailableSegmentLengths() as $index => $length) {
             $segIndices = $subSegmentMaximization->getIndizesOfMaximumForLengthIndex($index);
             $seg[$index] = [];
-            for($i = $segIndices[0]; $i <= $segIndices[1]; $i+=$precision){
+            for ($i = $segIndices[0]; $i <= $segIndices[1]; $i += $precision) {
                 $seg[$index][] = array($latLongs['lat'][$i], $latLongs['lng'][$i]);
             }
 

--- a/src/CoreBundle/Component/Activity/Tool/BestSubSegmentsStatistics.php
+++ b/src/CoreBundle/Component/Activity/Tool/BestSubSegmentsStatistics.php
@@ -4,6 +4,7 @@ namespace Runalyze\Bundle\CoreBundle\Component\Activity\Tool;
 
 use Runalyze\Calculation\Math\SubSegmentMaximization;
 use Runalyze\Model\Trackdata;
+use Runalyze\Model\Route\Entity as RouteEntity;
 
 class BestSubSegmentsStatistics
 {
@@ -69,6 +70,44 @@ class BestSubSegmentsStatistics
 
         $this->TimeSegments = new SubSegmentMaximization($distanceAsDeltas, $timeAsDeltas, $this->Times);
         $this->TimeSegments->maximize();
+    }
+
+    /**
+     * @param RouteEntity $route
+     * @return array
+     */
+    public function getDistanceSegmentPaths(RouteEntity $route)
+    {
+        return $this->getSegments($this->getDistanceSegments(), $route);
+    }
+
+    /**
+     * @param RouteEntity $route
+     * @return array
+     */
+    public function getTimeSegmentPaths(RouteEntity $route)
+    {
+        return $this->getSegments($this->getTimeSegments(), $route);
+    }
+
+    /**
+     * @param SubSegmentMaximization $subSegmentMaximization
+     * @param RouteEntity $route
+     * @return array
+     */
+    private function getSegments(SubSegmentMaximization $subSegmentMaximization, RouteEntity $route)
+    {
+        $latLongs = $route->latitudesAndLongitudesFromGeohash();
+        $seg = [];
+        foreach($subSegmentMaximization->getAvailableSegmentLengths() as $index => $length) {
+            $segIndices = $subSegmentMaximization->getIndizesOfMaximumForLengthIndex($index);
+            $seg[$index] = [];
+            for($i = $segIndices[0]; $i <= $segIndices[1]; $i++){
+                $seg[$index][] = array($latLongs['lat'][$i], $latLongs['lng'][$i]);
+            }
+
+        }
+        return $seg;
     }
 
     /**

--- a/src/CoreBundle/Controller/ActivityController.php
+++ b/src/CoreBundle/Controller/ActivityController.php
@@ -418,8 +418,9 @@ class ActivityController extends Controller
             )
         );
 
-        $distanceSegments = $statistics->getDistanceSegmentPaths($route);
-        $timeSegments = $statistics->getTimeSegmentPaths($route);
+        $precision = $this->get('app.configuration_manager')->getList()->getActivityView()->get('GMAP_PATH_PRECISION');
+        $distanceSegments = $statistics->getDistanceSegmentPaths($route, $precision);
+        $timeSegments = $statistics->getTimeSegmentPaths($route, $precision);
 
         return $this->render('activity/tool/best_sub_segments.html.twig', [
             'statistics' => $statistics,

--- a/src/CoreBundle/Controller/ActivityController.php
+++ b/src/CoreBundle/Controller/ActivityController.php
@@ -418,7 +418,7 @@ class ActivityController extends Controller
             )
         );
 
-        $precision = $this->get('app.configuration_manager')->getList()->getActivityView()->get('GMAP_PATH_PRECISION');
+        $precision = (int) $this->get('app.configuration_manager')->getList()->getActivityView()->get('GMAP_PATH_PRECISION');
         $distanceSegments = $statistics->getDistanceSegmentPaths($route, $precision);
         $timeSegments = $statistics->getTimeSegmentPaths($route, $precision);
 

--- a/src/CoreBundle/Controller/ActivityController.php
+++ b/src/CoreBundle/Controller/ActivityController.php
@@ -13,6 +13,7 @@ use Runalyze\Bundle\CoreBundle\Entity\Trackdata;
 use Runalyze\Bundle\CoreBundle\Entity\Training;
 use Runalyze\Metrics\Velocity\Unit\PaceEnum;
 use Runalyze\Service\ElevationCorrection\StepwiseElevationProfileFixer;
+use Runalyze\View\Leaflet\Map;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\ParamConverter;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
@@ -405,10 +406,27 @@ class ActivityController extends Controller
         $statistics->setTimesToAnalyze([30, 60, 120, 300, 600, 720, 1800, 3600, 7200]);
         $statistics->findSegments();
 
+        $Frontend = new \Frontend(false, $this->get('security.token_storage'));
+        $context = new Context($id, $account->getId());
+        $route = $context->route();
+        $map = new Map('map-'.$trackdata->getActivity()->getActivityId());
+        $map->addRoute(
+            new \Runalyze\View\Leaflet\Activity(
+                'route-'.$trackdata->getActivity()->getActivityId(),
+                $route,
+                $trackdataModel
+            )
+        );
+
+        $distanceSegments = $statistics->getDistanceSegmentPaths($route);
+        $timeSegments = $statistics->getTimeSegmentPaths($route);
+
         return $this->render('activity/tool/best_sub_segments.html.twig', [
             'statistics' => $statistics,
             'distanceArray' => $trackdataModel->distance(),
-            'paceUnit' => $paceUnit
+            'paceUnit' => $paceUnit,
+            'segments' => ['time' => $timeSegments, 'distance' => $distanceSegments],
+            'map' => $map->code(),
         ]);
     }
 


### PR DESCRIPTION
This PR does the following
* adds a map layer to the sub segments view
* highlights the segment when you move the mouse over the segment row
* changes the sub segments view size to "normal"
* on mobile devices (only tested on my phone) the path gets highlighted after you tap on the row

Open issues from reviews:
* [ ] multiple map support / main activity's map is destroyed when opening the sub segments view
* [ ] take care of activities without route information

I'm (as always) open to feedback :)

![sub-segment-paths](https://user-images.githubusercontent.com/4430279/33799763-699d7b34-dd32-11e7-9fa7-cc32aebc1558.gif)



